### PR TITLE
Requirements for container platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 click~=7.1
 idmtools~=1.7
 idmtools-platform-comps~=1.7
+idmtools-platform-container~=1.7
 idmtools-models~=1.7
 emod-api~=1.30
 matplotlib


### PR DESCRIPTION
The 1.7.11 release of idmtools added container platform as an option. This requirement change is needed to get that option working.

Also Docker and several other things, but this is the only _emodpy_ change needed.

Best to keep versioning on platform-container and platform-comps the same. Latest release on both is 2.0, but keeping it at ~1.7 right now is fine.