### PR TITLE
Formatting fixes to code examples in docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,3 @@ Have a question or a comment? Check out our
 If you have feature requests, issues, or new code, please see our
 [CONTRIBUTING](https://github.com/EMOD-Hub/.github/blob/main/CONTRIBUTING.md)
 page for how to provide your feedback.
-
-## Disclaimer
-
-The code in this repository was developed by IDM and other collaborators to support our
-joint research on flexible agent-based modeling. We've made it publicly available under
-the MIT License to provide others with a better understanding of our research and an
-opportunity to build upon it for their own work. We make no representations that the code
-works as intended or that we will provide support, address issues that are found, or accept
-pull requests. You are welcome to create your own fork and modify the code to suit your own
-modeling needs as permitted under the MIT License.

--- a/emodpy/campaign/common.py
+++ b/emodpy/campaign/common.py
@@ -148,12 +148,12 @@ class TargetDemographicsConfig:
             - Defaults to False.
 
     Examples:
-        >>> # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
-        >>> from emodpy.campaign.common import TargetDemographicsConfig, TargetGender
-        >>> from emodpy.campaign.distributor import add_intervention_scheduled
-        >>> demographics_config = TargetDemographicsConfig(demographic_coverage=0.5, target_age_min=10,
-        >>>                                                target_age_max=20, target_gender=TargetGender.FEMALE)
-        >>> add_intervention_scheduled(demographics_config=demographics_config, ...)
+        # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
+        from emodpy.campaign.common import TargetDemographicsConfig, TargetGender
+        from emodpy.campaign.distributor import add_intervention_scheduled
+        demographics_config = TargetDemographicsConfig(demographic_coverage=0.5, target_age_min=10,
+                                                       target_age_max=20, target_gender=TargetGender.FEMALE)
+        add_intervention_scheduled(demographics_config=demographics_config, ...)
     """
     class _TargetDemographic(Enum):
         EVERYONE = "Everyone"
@@ -241,11 +241,11 @@ class RepetitionConfig:
         ValueError: if timesteps_between_repetitions is undefined when number_repetitions is used.
 
     Examples:
-        >>> # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
-        >>> from emodpy.campaign.common import RepetitionConfig
-        >>> from emodpy.campaign.distributor import add_intervention_scheduled
-        >>> repetition_config = RepetitionConfig(number_repetitions=2, timesteps_between_repetitions=365)
-        >>> add_intervention_scheduled(repetition_config=repetition_config, ...)
+        # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
+        from emodpy.campaign.common import RepetitionConfig
+        from emodpy.campaign.distributor import add_intervention_scheduled
+        repetition_config = RepetitionConfig(number_repetitions=2, timesteps_between_repetitions=365)
+        add_intervention_scheduled(repetition_config=repetition_config, ...)
 
     """
     def __init__(self, number_repetitions: int = 1, timesteps_between_repetitions: int = None,
@@ -340,20 +340,20 @@ class PropertyRestrictions:
     Examples:
         Example 1: This example demonstrates how to specify individual restrictions for targeting specific groups of people who are high risk AND whose InterventionStatus is ARTStaging.
 
-        >>> # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
-        >>> from emodpy.campaign.common import PropertyRestrictions
-        >>> from emodpy.campaign.distributor import add_intervention_scheduled
-        >>> property_restrictions = PropertyRestrictions(individual_property_restrictions=[["Risk:HIGH", "InterventionStatus:ARTStaging"]])
-        >>> add_intervention_scheduled(property_restrictions=property_restrictions, ...)
-        >>> # the result json should look like this:
-        >>> # {
-        >>> #          "Property_Restrictions_Within_Node": [
-        >>> #            {
-        >>> #              "Risk": "HIGH",
-        >>> #              "InterventionStatus": "ARTStaging"
-        >>> #            }
-        >>> #          ]
-        >>> # }
+        # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
+        from emodpy.campaign.common import PropertyRestrictions
+        from emodpy.campaign.distributor import add_intervention_scheduled
+        property_restrictions = PropertyRestrictions(individual_property_restrictions=[["Risk:HIGH", "InterventionStatus:ARTStaging"]])
+        add_intervention_scheduled(property_restrictions=property_restrictions, ...)
+        # the result json should look like this:
+        # {
+        #          "Property_Restrictions_Within_Node": [
+        #            {
+        #              "Risk": "HIGH",
+        #              "InterventionStatus": "ARTStaging"
+        #            }
+        #          ]
+        # }
 
 
         Example 2: This example demonstrates how to specify individual restrictions for targeting specific groups of people. In this case, we are targeting individuals whose InterventionStatus is set to ARTStaging and who have either HIGH or MEDIUM risk behavior. In other words, we aim to target individuals who meet either of the following conditions:
@@ -361,54 +361,54 @@ class PropertyRestrictions:
                     1. "InterventionStatus is set to ARTStaging and Risk is set to HIGH"
                     2. "InterventionStatus is set to ARTStaging AND Risk is set to MEDIUM"
 
-        >>> # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
-        >>> from emodpy.campaign.common import PropertyRestrictions
-        >>> from emodpy.campaign.distributor import add_intervention_scheduled
-        >>> property_restrictions_within_node = PropertyRestrictions(
-        >>>                                       individual_property_restrictions=[
-        >>>                                                 ["Risk:HIGH", "InterventionStatus:ARTStaging"],
-        >>>                                                 ["Risk:MEDIUM", "InterventionStatus:ARTStaging"]])
-        >>> add_intervention_scheduled(property_restrictions=property_restrictions, ...)
-        >>> # the result json should look like this:
-        >>> # {
-        >>> #          "Property_Restrictions_Within_Node": [
-        >>> #            {
-        >>> #              "Risk": "HIGH",
-        >>> #              "InterventionStatus": "ARTStaging"
-        >>> #            },
-        >>> #            {
-        >>> #              "Risk": "MEDIUM",
-        >>> #              "InterventionStatus": "ARTStaging"
-        >>> #            }
-        >>> #          ]
-        >>> # }
+        # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
+        from emodpy.campaign.common import PropertyRestrictions
+        from emodpy.campaign.distributor import add_intervention_scheduled
+        property_restrictions_within_node = PropertyRestrictions(
+                                              individual_property_restrictions=[
+                                                        ["Risk:HIGH", "InterventionStatus:ARTStaging"],
+                                                        ["Risk:MEDIUM", "InterventionStatus:ARTStaging"]])
+        add_intervention_scheduled(property_restrictions=property_restrictions, ...)
+        # the result json should look like this:
+        # {
+        #          "Property_Restrictions_Within_Node": [
+        #            {
+        #              "Risk": "HIGH",
+        #              "InterventionStatus": "ARTStaging"
+        #            },
+        #            {
+        #              "Risk": "MEDIUM",
+        #              "InterventionStatus": "ARTStaging"
+        #            }
+        #          ]
+        # }
 
         Example 3: This example demonstrates how to use 'node_property_restrictions' to specify the NodeProperty. In this case, we are targeting nodes that meet either of the following conditions:
 
-                    1. "Risk is set to MEDIUM and Place is set to URBAN"
-                    2. "Risk is set to LOW and Place is set to RURAL"
+        1. "Risk is set to MEDIUM and Place is set to URBAN"
+        2. "Risk is set to LOW and Place is set to RURAL"
 
-        >>> # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
-        >>> from emodpy.campaign.common import PropertyRestrictions
-        >>> from emodpy.campaign.distributor import add_intervention_scheduled
-        >>> property_restrictions = PropertyRestrictions(
-        >>>                            node_property_restrictions=[
-        >>>                                                 ["Risk:MEDIUM", "Place:URBAN"],
-        >>>                                                 ["Risk:LOW", "Place:RURAL"]])
-        >>> add_intervention_scheduled(property_restrictions=property_restrictions, ...)
-        >>> # the result json should look like this:
-        >>> # {
-        >>> #          "Node_Property_Restrictions": [
-        >>> #            {
-        >>> #              "Risk": "MEDIUM",
-        >>> #              "Place": "URBAN"
-        >>> #            },
-        >>> #            {
-        >>> #              "Risk": "LOW",
-        >>> #              "Place": "RURAL"
-        >>> #            }
-        >>> #          ]
-        >>> # }
+        # replace emodpy with emodpy_hiv or emodpy_malaria based on the disease you are working on.
+        from emodpy.campaign.common import PropertyRestrictions
+        from emodpy.campaign.distributor import add_intervention_scheduled
+        property_restrictions = PropertyRestrictions(
+                                   node_property_restrictions=[
+                                                        ["Risk:MEDIUM", "Place:URBAN"],
+                                                        ["Risk:LOW", "Place:RURAL"]])
+        add_intervention_scheduled(property_restrictions=property_restrictions, ...)
+        # the result json should look like this:
+        # {
+        #          "Node_Property_Restrictions": [
+        #            {
+        #              "Risk": "MEDIUM",
+        #              "Place": "URBAN"
+        #            },
+        #            {
+        #              "Risk": "LOW",
+        #              "Place": "RURAL"
+        #            }
+        #          ]
+        # }
 
     """
     def __init__(self, individual_property_restrictions: List[List[str]] = None,

--- a/emodpy/campaign/distributor.py
+++ b/emodpy/campaign/distributor.py
@@ -87,40 +87,40 @@ def add_intervention_scheduled(campaign: api_campaign,
     Returns:
         None, add the configuration to the campaign.
 
-    Example:
-        >>> from emodpy.campaign.distributor import add_intervention_scheduled
-        >>> from emodpy.campaign.common import TargetDemographicsConfig, RepetitionConfig, PropertyRestrictions, TargetGender
-        >>> from emodpy.campaign.individual_intervention import BroadcastEvent, OutbreakIndividual
-        >>> from emodpy.utils.distributions import UniformDistribution
-        >>> from emodpy.utils.targeting_config import IsPregnant
-        >>> from emod_api import campaign as api_campaign
-        >>> my_campaign = api_campaign
-        >>> my_campaign.set_schema('path_to_schema.json')
-        >>> # Create a list of interventions containing a BroadcastEvent and an OutbreakIndividual
-        >>> my_intervention_list = [BroadcastEvent(my_campaign, broadcast_event="received_outbreak"),
-        >>>                         OutbreakIndividual(my_campaign)]
-        >>> # Create a UniformDistribution for the delay_distribution
-        >>> uniform_distribution = UniformDistribution(0, 365)
-        >>> # Create an IsPregnant targeting config
-        >>> is_pregnant = IsPregnant()
-        >>> # Add the event to the campaign, please note that only the first 2 arguments and start_day or start_year are required.
-        >>> add_intervention_scheduled(
-        >>>     campaign=my_campaign,
-        >>>     intervention_list=my_intervention_list,
-        >>>     # Distribute the interventions on January 1st, 1990.
-        >>>     start_year=1990,
-        >>>     event_name="test_event",
-        >>>     # Distribute the interventions to nodes (or the people there in) 1, 2, 3
-        >>>     node_ids=[1, 2, 3],
-        >>>     # Distribute the interventions twice with 365 timesteps between repetitions
-        >>>     repetition_config=RepetitionConfig(number_repetitions=2, timesteps_between_repetitions=365),
-        >>>     # Target 70% of female individuals whose Risk is High and are pregnant
-        >>>     target_demographics_config=TargetDemographicsConfig(demographic_coverage=0.7, target_gender=TargetGender.FEMALE),
-        >>>     property_restrictions=PropertyRestrictions(individual_property_restrictions=[["Risk:High"]]),
-        >>>     targeting_config=is_pregnant,
-        >>>     # Add a uniform delay (from 0 to 365 days) before the actual intervention is distributed
-        >>>     delay_distribution=uniform_distribution
-        >>> )
+    Examples:
+        from emodpy.campaign.distributor import add_intervention_scheduled
+        from emodpy.campaign.common import TargetDemographicsConfig, RepetitionConfig, PropertyRestrictions, TargetGender
+        from emodpy.campaign.individual_intervention import BroadcastEvent, OutbreakIndividual
+        from emodpy.utils.distributions import UniformDistribution
+        from emodpy.utils.targeting_config import IsPregnant
+        from emod_api import campaign as api_campaign
+        my_campaign = api_campaign
+        my_campaign.set_schema('path_to_schema.json')
+        # Create a list of interventions containing a BroadcastEvent and an OutbreakIndividual
+        my_intervention_list = [BroadcastEvent(my_campaign, broadcast_event="received_outbreak"),
+                                OutbreakIndividual(my_campaign)]
+        # Create a UniformDistribution for the delay_distribution
+        uniform_distribution = UniformDistribution(0, 365)
+        # Create an IsPregnant targeting config
+        is_pregnant = IsPregnant()
+        # Add the event to the campaign, please note that only the first 2 arguments and start_day or start_year are required.
+        add_intervention_scheduled(
+            campaign=my_campaign,
+            intervention_list=my_intervention_list,
+            # Distribute the interventions on January 1st, 1990.
+            start_year=1990,
+            event_name="test_event",
+            # Distribute the interventions to nodes (or the people there in) 1, 2, 3
+            node_ids=[1, 2, 3],
+            # Distribute the interventions twice with 365 timesteps between repetitions
+            repetition_config=RepetitionConfig(number_repetitions=2, timesteps_between_repetitions=365),
+            # Target 70% of female individuals whose Risk is High and are pregnant
+            target_demographics_config=TargetDemographicsConfig(demographic_coverage=0.7, target_gender=TargetGender.FEMALE),
+            property_restrictions=PropertyRestrictions(individual_property_restrictions=[["Risk:High"]]),
+            targeting_config=is_pregnant,
+            # Add a uniform delay (from 0 to 365 days) before the actual intervention is distributed
+            delay_distribution=uniform_distribution
+        )
     """
     # Create a DelayedIntervention with the intervention if a delay_distribution is provided
     intervention_list = _add_delay(campaign, delay_distribution, intervention_list)
@@ -215,44 +215,44 @@ def add_intervention_triggered(campaign: api_campaign,
             - Please refer to the emodpy.utils.targeting_config module for more information.
             - If None (default), then there is not extra targeting.
 
-    Example:
-        >>> from emodpy.campaign.distributor import add_intervention_triggered
-        >>> from emodpy.campaign.common import TargetDemographicsConfig, RepetitionConfig, PropertyRestrictions, TargetGender
-        >>> from emodpy.campaign.individual_intervention import BroadcastEvent, OutbreakIndividual
-        >>> from emodpy.utils.distributions import ExponentialDistribution
-        >>> from emodpy.utils.targeting_config import IsPregnant
-        >>> from emod_api import campaign as api_campaign
-        >>> my_campaign = api_campaign
-        >>> my_campaign.set_schema('path_to_schema.json')
-        >>> # Create a list of interventions containing a BroadcastEvent and an OutbreakIndividual
-        >>> my_intervention_list = [BroadcastEvent(my_campaign, broadcast_event="received_outbreak"),
-        >>>                         OutbreakIndividual(my_campaign)]
-        >>> # Create an ExponentialDistribution for the delay_distribution with a mean of 10 timesteps
-        >>> exponential_distribution = ExponentialDistribution(10)
-        >>> # Create an is not pregnant targeting config
-        >>> is_not_pregnant = ~IsPregnant()
-        >>> # Add the event to the campaign, please note that only the first 3 arguments and start_day or start_year are required.
-        >>> add_intervention_triggered(my_campaign,
-        >>>                            my_intervention_list,
-        >>>                            # Trigger the distribution of the intervention when either of the events: "trigger1" or "trigger2" are broadcast.
-        >>>                            triggers_list=["trigger1", "trigger2"],
-        >>>                            # Listen to the triggers for 30 days.
-        >>>                            duration=30,
-        >>>                            # Start the event at the 730th timestep.
-        >>>                            start_day=730,
-        >>>                            event_name="test_event",
-        >>>                            # Have nodes 1, 2, 3 listen for the event and distribute the intervention to the people in those nodes.
-        >>>                            node_ids=[1, 2, 3],
-        >>>                            # Add a delay between the trigger and the actual intervention
-        >>>                            delay_distribution=exponential_distribution,
-        >>>                            # Target 70% of female individual from age 10 to 20 whose Risk is High and are not pregnant
-        >>>                            target_demographics_config=TargetDemographicsConfig(demographic_coverage=0.7,
-        >>>                                                                                target_gender=TargetGender.FEMALE,
-        >>>                                                                                target_age_min=10,
-        >>>                                                                                target_age_max=20),
-        >>>                            property_restrictions=PropertyRestrictions(individual_property_restrictions=[["Risk:High"]])
-        >>>                            targeting_config=is_not_pregnant
-        >>> )
+    Examples:
+        from emodpy.campaign.distributor import add_intervention_triggered
+        from emodpy.campaign.common import TargetDemographicsConfig, RepetitionConfig, PropertyRestrictions, TargetGender
+        from emodpy.campaign.individual_intervention import BroadcastEvent, OutbreakIndividual
+        from emodpy.utils.distributions import ExponentialDistribution
+        from emodpy.utils.targeting_config import IsPregnant
+        from emod_api import campaign as api_campaign
+        my_campaign = api_campaign
+        my_campaign.set_schema('path_to_schema.json')
+        # Create a list of interventions containing a BroadcastEvent and an OutbreakIndividual
+        my_intervention_list = [BroadcastEvent(my_campaign, broadcast_event="received_outbreak"),
+                                OutbreakIndividual(my_campaign)]
+        # Create an ExponentialDistribution for the delay_distribution with a mean of 10 timesteps
+        exponential_distribution = ExponentialDistribution(10)
+        # Create an is not pregnant targeting config
+        is_not_pregnant = ~IsPregnant()
+        # Add the event to the campaign, please note that only the first 3 arguments and start_day or start_year are required.
+        add_intervention_triggered(my_campaign,
+                                   my_intervention_list,
+                                   # Trigger the distribution of the intervention when either of the events: "trigger1" or "trigger2" are broadcast.
+                                   triggers_list=["trigger1", "trigger2"],
+                                   # Listen to the triggers for 30 days.
+                                   duration=30,
+                                   # Start the event at the 730th timestep.
+                                   start_day=730,
+                                   event_name="test_event",
+                                   # Have nodes 1, 2, 3 listen for the event and distribute the intervention to the people in those nodes.
+                                   node_ids=[1, 2, 3],
+                                   # Add a delay between the trigger and the actual intervention
+                                   delay_distribution=exponential_distribution,
+                                   # Target 70% of female individual from age 10 to 20 whose Risk is High and are not pregnant
+                                   target_demographics_config=TargetDemographicsConfig(demographic_coverage=0.7,
+                                                                                       target_gender=TargetGender.FEMALE,
+                                                                                       target_age_min=10,
+                                                                                       target_age_max=20),
+                                   property_restrictions=PropertyRestrictions(individual_property_restrictions=[["Risk:High"]])
+                                   targeting_config=is_not_pregnant
+        )
 
     Returns:
         None, add the configuration to the campaign.

--- a/emodpy/campaign/waning_config.py
+++ b/emodpy/campaign/waning_config.py
@@ -270,9 +270,9 @@ class MapLinear(BaseWaningConfig):
         730 and 1460. The value at time 395 is 10.821918, which is calculated by linear interpolation between the values
         at times 365 and 730, (20-10)*(395-365)/(730-365) + 10 , and so on.
 
-        >>> times = [365, 730, 1460, 3650]
-        >>> effects = [10, 20, 33, 40]
-        >>> wc = MapLinear(times=times, effects=effects)
+        times = [365, 730, 1460, 3650]
+        effects = [10, 20, 33, 40]
+        wc = MapLinear(times=times, effects=effects)
     """
 
     def __init__(self, times: list[float], effects: list[float], effect_multiplier: float = 1,

--- a/emodpy/utils/targeting_config.py
+++ b/emodpy/utils/targeting_config.py
@@ -10,106 +10,106 @@ a relationship.
 Below is the JSON for a simple example where we want to distribute a vaccine to 20%
 of the people that do not already have the vaccine on the 100th day of the simulation.
 
-    >>> {
-    >>>     "class": "CampaignEvent",
-    >>>     "Start_Day": 100,
-    >>>     "Nodeset_Config": {
-    >>>         "class": "NodeSetAll"
-    >>>     },
-    >>>     "Event_Coordinator_Config": {
-    >>>         "class": "StandardInterventionDistributionEventCoordinator",
-    >>>         "Target_Demographic": "Everyone",
-    >>>         "Demographic_Coverage": 0.2,
-    >>>         "Targeting_Config": {
-    >>>             "class": "HasIntervention",
-    >>>             "Is_Equal_To": 0,
-    >>>             "Intervention_Name": "MyVaccine"
-    >>>         },
-    >>>         "Intervention_Config": {
-    >>>             "class": "SimpleVaccine",
-    >>>             "Intervention_Name" : "MyVaccine",
-    >>>             "Cost_To_Consumer": 1,
-    >>>             "Vaccine_Take": 1,
-    >>>             "Vaccine_Type": "AcquisitionBlocking",
-    >>>             "Waning_Config": {
-    >>>                 "class": "WaningEffectConstant",
-    >>>                 "Initial_Effect" : 1.0
-    >>>             }
-    >>>         }
-    >>>     }
-    >>> }
+    {
+        "class": "CampaignEvent",
+        "Start_Day": 100,
+        "Nodeset_Config": {
+            "class": "NodeSetAll"
+        },
+        "Event_Coordinator_Config": {
+            "class": "StandardInterventionDistributionEventCoordinator",
+            "Target_Demographic": "Everyone",
+            "Demographic_Coverage": 0.2,
+            "Targeting_Config": {
+                "class": "HasIntervention",
+                "Is_Equal_To": 0,
+                "Intervention_Name": "MyVaccine"
+            },
+            "Intervention_Config": {
+                "class": "SimpleVaccine",
+                "Intervention_Name" : "MyVaccine",
+                "Cost_To_Consumer": 1,
+                "Vaccine_Take": 1,
+                "Vaccine_Type": "AcquisitionBlocking",
+                "Waning_Config": {
+                    "class": "WaningEffectConstant",
+                    "Initial_Effect" : 1.0
+                }
+            }
+        }
+    }
 
 Below is a slightly more complicated example where we want to distribute a diagnostic
 to people that are either high risk or have not been vaccinated.
 
-    >>> {
-    >>>     "class": "CampaignEvent",
-    >>>     "Start_Day": 100,
-    >>>     "Nodeset_Config": {
-    >>>         "class": "NodeSetAll"
-    >>>     },
-    >>>     "Event_Coordinator_Config": {
-    >>>         "class": "StandardInterventionDistributionEventCoordinator",
-    >>>         "Target_Demographic": "Everyone",
-    >>>         "Demographic_Coverage": 0.2,
-    >>>         "Targeting_Config": {
-    >>>             "class" : "TargetingLogic",
-    >>>             "Logic" : [
-    >>>                 [
-    >>>                     {
-    >>>                         "class": "HasIntervention",
-    >>>                         "Is_Equal_To": 0,
-    >>>                         "Intervention_Name": "MyVaccine"
-    >>>                     }
-    >>>                 ],
-    >>>                 [
-    >>>                     {
-    >>>                         "class": "HasIP",
-    >>>                         "Is_Equal_To": 1,
-    >>>                         "IP_Key_Value": "Risk:HIGH"
-    >>>                     }
-    >>>                 ]
-    >>>             ]
-    >>>         },
-    >>>         "Intervention_Config": {
-    >>>             "class": "SimpleDiagnostic",
-    >>>             "Treatment_Fraction": 1.0,
-    >>>             "Base_Sensitivity": 1.0,
-    >>>             "Base_Specificity": 1.0,
-    >>>             "Event_Or_Config": "Event",
-    >>>             "Positive_Diagnosis_Event": "TestedPositive"
-    >>>         }
-    >>>     }
-    >>> }
+    {
+        "class": "CampaignEvent",
+        "Start_Day": 100,
+        "Nodeset_Config": {
+            "class": "NodeSetAll"
+        },
+        "Event_Coordinator_Config": {
+            "class": "StandardInterventionDistributionEventCoordinator",
+            "Target_Demographic": "Everyone",
+            "Demographic_Coverage": 0.2,
+            "Targeting_Config": {
+                "class" : "TargetingLogic",
+                "Logic" : [
+                    [
+                        {
+                            "class": "HasIntervention",
+                            "Is_Equal_To": 0,
+                            "Intervention_Name": "MyVaccine"
+                        }
+                    ],
+                    [
+                        {
+                            "class": "HasIP",
+                            "Is_Equal_To": 1,
+                            "IP_Key_Value": "Risk:HIGH"
+                        }
+                    ]
+                ]
+            },
+            "Intervention_Config": {
+                "class": "SimpleDiagnostic",
+                "Treatment_Fraction": 1.0,
+                "Base_Sensitivity": 1.0,
+                "Base_Specificity": 1.0,
+                "Event_Or_Config": "Event",
+                "Positive_Diagnosis_Event": "TestedPositive"
+            }
+        }
+    }
 
 The classes of emodpy are intended to make it easier for users to create complex logic and
 reduce the burden of trying to create this complex logic in JSON.  Below is the python
 configuration logic for the two examples above:
 
-    >>> # Example 1: Does not have MyVaccine
-    >>> targeting_config = ~HasIntervention( intervention_name="MyVaccine" )
-    >>>
-    >>> # Example 2: Does not have MyVaccine OR is high risk
-    >>> targeting_config = ~HasIntervention( intervention_name="MyVaccine" ) | HasIP( ip_key_value="Risk:HIGH" )
+    # Example 1: Does not have MyVaccine
+    targeting_config = ~HasIntervention( intervention_name="MyVaccine" )
+
+    # Example 2: Does not have MyVaccine OR is high risk
+    targeting_config = ~HasIntervention( intervention_name="MyVaccine" ) | HasIP( ip_key_value="Risk:HIGH" )
 
 Notice that this logic uses the bitwise operators instead of the logical operators.
 Python does not allow you to override the logical operators so the bitwise operators
 were the next best thing to allow simple notation.  The bitwise operators are:
 
-    * '~' - use instead of "not" to logically invert the logical check
-    * '&' - use instead of "and" to logically AND two logical checks
-    * '|' - use instead of "or" to logically OR two logical checks
-    * '^' - XOR - NOT SUPPORTED
-    * '<<' - Left Shift - NOT SUPPORTED
-    * '>>' - Right Shift - NOT SUPPORTED
+* '~' - use instead of "not" to logically invert the logical check
+* '&' - use instead of "and" to logically AND two logical checks
+* '|' - use instead of "or" to logically OR two logical checks
+* '^' - XOR - NOT SUPPORTED
+* '<<' - Left Shift - NOT SUPPORTED
+* '>>' - Right Shift - NOT SUPPORTED
 
 The order of operations for bitwise operators is the same as for logical operators.
 For the operators we support, the following order of operations is followed:
 
-    1) Parentheses
-    2) '~' - NOT
-    3) '&' - AND
-    4) '|' - OR
+1. Parentheses
+2. '~' - NOT
+3. '&' - AND
+4. '|' - OR
 
 Please note that the bitwise operations should not change objects directly.  You expect
 them to return a new object with the operation.  For example, if you have A_prime = ~A,


### PR DESCRIPTION
This fixes the formatting issues you were seeing in campaign/distributor. The empty API reference topics you saw just didn't include docstrings in the classes/functions, so that's out of scope for the cleanup tasks. 